### PR TITLE
Fix Tabu Local Searches in max-p

### DIFF
--- a/region/notebooks/debug_code_MULTIPLE_TESTS.ipynb
+++ b/region/notebooks/debug_code_MULTIPLE_TESTS.ipynb
@@ -1,0 +1,254 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "\n",
+    "import geopandas as gpd\n",
+    "import numpy as np\n",
+    "from pysal.viz.splot.libpysal import plot_spatial_weights\n",
+    "from libpysal.weights import Queen, Rook\n",
+    "from region.max_p_regions.heuristics import MaxPRegionsHeu\n",
+    "from region.p_regions.azp import *\n",
+    "from region.csgraph_utils import *\n",
+    "import scipy\n",
+    "import scipy.sparse.csgraph as csg\n",
+    "\n",
+    "gdf = gpd.read_file('reg_lat_10_10.shp')\n",
+    "\n",
+    "np.random.seed(123)\n",
+    "gdf['pop'] = np.random.randint(500, high=1000, size=100)\n",
+    "np.random.seed(123)\n",
+    "gdf['income_pp'] = np.random.uniform(low=50000, high=100000, size=100)\n",
+    "\n",
+    "w_queen = Queen.from_dataframe(gdf)\n",
+    "w_rook = Rook.from_dataframe(gdf)\n",
+    "adj = scipy.sparse.csr_matrix(w_rook.full()[0])\n",
+    "\n",
+    "values_gdf = gdf[['income_pp']]\n",
+    "spatially_extensive_attr_gdf = gdf[['pop']].values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from joblib import Parallel, delayed\n",
+    "import multiprocessing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Draw inspiration from https://blog.dominodatalab.com/simple-parallelization/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inputs = range(100, 125)\n",
+    "threshold = 10000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_cores = multiprocessing.cpu_count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Problems in Threshold: False\n",
+      "Problems in Contiguity: False\n"
+     ]
+    }
+   ],
+   "source": [
+    "def processInput(i):\n",
+    "    model = MaxPRegionsHeu(local_search = AZP(), random_state=i)\n",
+    "    model.fit_from_w(w_rook, values_gdf.values, spatially_extensive_attr_gdf, threshold = threshold)\n",
+    "    gdf['labels'] = model.labels_\n",
+    "    return [any(gdf.groupby('labels')['pop'].sum() < threshold), not boolean_assert_feasible(gdf['labels'], adj)]\n",
+    "     \n",
+    "results = Parallel(n_jobs=num_cores)(delayed(processInput)(i) for i in inputs)\n",
+    "\n",
+    "thr_aux = [l[0] for l in results]\n",
+    "con_aux = [l[1] for l in results]\n",
+    "\n",
+    "print('Problems in Threshold: {}'.format(any(thr_aux)))\n",
+    "print('Problems in Contiguity: {}'.format(any(con_aux)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "AZP_thr_aux = thr_aux\n",
+    "AZP_con_aux = con_aux"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Problems in Threshold: False\n",
+      "Problems in Contiguity: False\n"
+     ]
+    }
+   ],
+   "source": [
+    "def processInput(i):\n",
+    "    model = MaxPRegionsHeu(local_search = AZPBasicTabu(), random_state=i)\n",
+    "    model.fit_from_w(w_rook, values_gdf.values, spatially_extensive_attr_gdf, threshold = threshold)\n",
+    "    gdf['labels'] = model.labels_\n",
+    "    return [any(gdf.groupby('labels')['pop'].sum() < threshold), not boolean_assert_feasible(gdf['labels'], adj)]\n",
+    "     \n",
+    "results = Parallel(n_jobs=num_cores)(delayed(processInput)(i) for i in inputs)\n",
+    "\n",
+    "thr_aux = [l[0] for l in results]\n",
+    "con_aux = [l[1] for l in results]\n",
+    "\n",
+    "print('Problems in Threshold: {}'.format(any(thr_aux)))\n",
+    "print('Problems in Contiguity: {}'.format(any(con_aux)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "AZPBasicTabu_thr_aux = thr_aux\n",
+    "AZPBasicTabu_con_aux = con_aux"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Problems in Threshold: False\n",
+      "Problems in Contiguity: False\n"
+     ]
+    }
+   ],
+   "source": [
+    "def processInput(i):\n",
+    "    model = MaxPRegionsHeu(local_search = AZPReactiveTabu(max_iterations = 2, k1 = 2, k2 = 2), random_state=i)\n",
+    "    model.fit_from_w(w_rook, values_gdf.values, spatially_extensive_attr_gdf, threshold = threshold)\n",
+    "    gdf['labels'] = model.labels_\n",
+    "    return [any(gdf.groupby('labels')['pop'].sum() < threshold), not boolean_assert_feasible(gdf['labels'], adj)]\n",
+    "     \n",
+    "results = Parallel(n_jobs=num_cores)(delayed(processInput)(i) for i in inputs)\n",
+    "\n",
+    "thr_aux = [l[0] for l in results]\n",
+    "con_aux = [l[1] for l in results]\n",
+    "\n",
+    "print('Problems in Threshold: {}'.format(any(thr_aux)))\n",
+    "print('Problems in Contiguity: {}'.format(any(con_aux)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "AZPReactiveTabu_thr_aux = thr_aux\n",
+    "AZPReactiveTabu_con_aux = con_aux"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Problems in Threshold: False\n",
+      "Problems in Contiguity: False\n"
+     ]
+    }
+   ],
+   "source": [
+    "def processInput(i):\n",
+    "    model = MaxPRegionsHeu(local_search = AZPSimulatedAnnealing(init_temperature=1), random_state=i)\n",
+    "    model.fit_from_w(w_rook, values_gdf.values, spatially_extensive_attr_gdf, threshold = threshold)\n",
+    "    gdf['labels'] = model.labels_\n",
+    "    return [any(gdf.groupby('labels')['pop'].sum() < threshold), not boolean_assert_feasible(gdf['labels'], adj)]\n",
+    "     \n",
+    "results = Parallel(n_jobs=num_cores)(delayed(processInput)(i) for i in inputs)\n",
+    "\n",
+    "thr_aux = [l[0] for l in results]\n",
+    "con_aux = [l[1] for l in results]\n",
+    "\n",
+    "print('Problems in Threshold: {}'.format(any(thr_aux)))\n",
+    "print('Problems in Contiguity: {}'.format(any(con_aux)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "AZPSimulatedAnnealing_thr_aux = thr_aux\n",
+    "AZPSimulatedAnnealing_con_aux = con_aux"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/region/p_regions/azp.py
+++ b/region/p_regions/azp.py
@@ -963,8 +963,9 @@ class AZPReactiveTabu(AZPTabu):
                 if obj_val_diff < best_objval_diff:
                     best_move_index, best_move = i, move
                     best_objval_diff = obj_val_diff
-            # step 5: Make the move. Update the tabu status.
-            self._make_move(best_move.area, best_move.new_region, labels)
+            # step 5: Make the move if possible. Update the tabu status.
+            if self.allow_move_strategy(best_move.area, best_move.new_region, labels):
+                self._make_move(best_move.area, best_move.new_region, labels)
             # step 6: Look up the current zoning system in a list of all zoning
             # systems visited so far during the search. If not found then go
             # to step 10.
@@ -1000,9 +1001,9 @@ class AZPReactiveTabu(AZPTabu):
                         p = math.floor(1 + self.avg_it_until_rep / 2)
                         possible_moves.pop(best_move_index)
                         for _ in range(p):
-                            move = possible_moves.pop(
-                                random.randrange(len(possible_moves)))
-                            self._make_move(move.area, move.new_region, labels)
+                            move = possible_moves.pop(random.randrange(len(possible_moves)))
+                            if self.allow_move_strategy(move.area, move.new_region, labels):
+                                self._make_move(move.area, move.new_region, labels)
                         continue
                     # step 8: Update a moving average of the repetition
                     # interval self.avg_it_until_rep, and increase the

--- a/region/p_regions/azp.py
+++ b/region/p_regions/azp.py
@@ -713,7 +713,7 @@ class AZPTabu(AZP, abc.ABC):
     def _make_move(self, area, new_region, labels, adj):
         old_region = labels[area]
         make_move(area, new_region, labels)
-        if not boolean_assert_feasible(labels, adj):
+        if not boolean_assert_feasible(labels, adj): # If the move breaks the contiguity, revert it!
             make_move(area, old_region, labels) # Revert Move!
             reverse_move = Move(area, new_region, old_region)
             self.tabu.append(reverse_move)

--- a/region/p_regions/azp.py
+++ b/region/p_regions/azp.py
@@ -12,7 +12,7 @@ from region.p_regions.azp_util import AllowMoveStrategy, \
                                             AllowMoveAZP,\
                                             AllowMoveAZPSimulatedAnnealing
 from region.util import array_from_df_col, array_from_dict_values, \
-    assert_feasible, copy_func, count, generate_initial_sol, \
+    assert_feasible, boolean_assert_feasible, copy_func, count, generate_initial_sol, \
     make_move, Move, pop_randomly_from, random_element_from,\
     scipy_sparse_matrix_from_w, separate_components, w_from_gdf,\
     array_from_graph_or_dict, scipy_sparse_matrix_from_dict

--- a/region/p_regions/azp.py
+++ b/region/p_regions/azp.py
@@ -821,7 +821,7 @@ class AZPBasicTabu(AZPTabu):
                                     best_objval_diff = objval_diff
             # step 2: Make this move if it is an improvement or equivalet in
             # value.
-            if best_move is not None and best_objval_diff <= 0:
+            if best_move is not None and best_objval_diff <= 0 and self.allow_move_strategy(best_move.area, best_move.new_region, labels):
                 self._make_move(best_move.area, best_move.new_region, labels)
             else:
                 # step 3: if no improving move can be made, then see if a tabu
@@ -835,8 +835,10 @@ class AZPBasicTabu(AZPTabu):
                 ]
                 if improving_tabus:
                     aspiration_move = random_element_from(improving_tabus)
-                    self._make_move(aspiration_move.area,
-                                    aspiration_move.new_region, labels)
+                    
+                    if self.allow_move_strategy(aspiration_move.area, aspiration_move.new_region, labels):
+                    
+                        self._make_move(aspiration_move.area, aspiration_move.new_region, labels)
                 else:
                     # step 4: If there is no improving move and no aspirational
                     # move, then make the best move even if it is nonimproving
@@ -844,9 +846,8 @@ class AZPBasicTabu(AZPTabu):
                     # function).
                     if stop:
                         break
-                    if best_move is not None:
-                        self._make_move(best_move.area, best_move.new_region,
-                                        labels)
+                    if best_move is not None and self.allow_move_strategy(best_move.area, best_move.new_region, labels):
+                        self._make_move(best_move.area, best_move.new_region, labels)
         return labels
 
 

--- a/region/p_regions/azp.py
+++ b/region/p_regions/azp.py
@@ -846,6 +846,9 @@ class AZPBasicTabu(AZPTabu):
                     if self.allow_move_strategy(aspiration_move.area, aspiration_move.new_region, labels):
                     
                         self._make_move(aspiration_move.area, aspiration_move.new_region, labels, adj)
+                        
+                if stop:
+                        break
                 else:
                     # step 4: If there is no improving move and no aspirational
                     # move, then make the best move even if it is nonimproving

--- a/region/util.py
+++ b/region/util.py
@@ -12,6 +12,8 @@ import networkx as nx
 from libpysal import weights
 import pulp
 
+from region.csgraph_utils import sub_adj_matrix, is_connected
+
 Move = collections.namedtuple("move", "area old_region new_region")
 "A named tuple representing a move from `old_region` to `new_region`."  # sphinx
 
@@ -735,14 +737,14 @@ def assert_feasible(solution, adj, n_regions=None):
         if len(set(solution)) != n_regions:
             raise ValueError("The number of regions is {} but "
                              "should be {}".format(len(solution), n_regions))
+
     for region_label in set(solution):
-        _, comp_labels = csg.connected_components(adj)
-        # check whether equal region_label implies equal comp_label
-        comp_labels_in_region = comp_labels[solution == region_label]
-        if not all_elements_equal(comp_labels_in_region):
+        aux = sub_adj_matrix(adj, np.where(solution == region_label)[0])
+        
+        # check right contiguity
+        if not is_connected(aux):
             raise ValueError("Region {} is not spatially "
                              "contiguous.".format(region_label))
-
 
 def all_elements_equal(array):
     return np.max(array) == np.min(array)

--- a/region/util.py
+++ b/region/util.py
@@ -746,6 +746,25 @@ def assert_feasible(solution, adj, n_regions=None):
             raise ValueError("Region {} is not spatially "
                              "contiguous.".format(region_label))
 
+
+def boolean_assert_feasible(solution, adj, n_regions=None):
+    """
+    Return boolean version of assert_feasible
+    """
+    
+    resp = []
+    if n_regions is not None:
+        if len(set(solution)) != n_regions:
+            raise ValueError("The number of regions is {} but "
+                             "should be {}".format(len(solution), n_regions))
+
+    for region_label in set(solution):
+        aux = sub_adj_matrix(adj, np.where(solution == region_label)[0])
+        resp.append(is_connected(aux))
+
+    final_resp = all(resp)
+    return final_resp
+
 def all_elements_equal(array):
     return np.max(array) == np.min(array)
 


### PR DESCRIPTION
Hello, everyone,

After digging deep into the code (by studying it and adding several print statements) to check what was happening, I managed to understand how each class is linked to each other.

This PR addresses directly https://github.com/pysal/region/issues/32 and https://github.com/pysal/region/issues/31 and fixes **both** issues.

So, the bugs were happening in the `AZPBasicTabu` and `AZPReactiveTabu` and are divided in two: "spatial constraints" and "threshold constraints". I explain here each solution:

### Spatial constraints: 

- modification of `assert_feasible` (inside `util.py`) which was not testing appropriately contiguity for initial labels.

- creation of `boolean_assert_feasible` to check spatial feasibility and returning a boolean value for internal usage.

- tweak function `_make_move` from AZPTabu ensuring that the move will not break spatial contiguity (if it brakes, the move is reverted). It now uses the `adj` argument.

### Threshold constraints:

- both `AZPBasicTabu` and `AZPReactiveTabu` were not taking into consideration the "AllowMove" classes built in `azp_util.py`. A very important class, which is `AllowMoveAZPMaxPRegions` that tests for the limit of the threshold were not being used. However, now this was included in the `AZPBasicTabu` and `AZPReactiveTabu` inside each `_azp_connected_component` (you can see that the `AZP` class uses these classes).

- with the previous fix, whenever a new move is meant to be made (with `_make_move`) this condition (with `self.allow_move_strategy`) needs to be checked.

### Some extra comments:

- With these tweaks, Step 3 of AZPBasicTabu can fall into an infinite loop (like in other parts of `region`). In `region`, this is solved with an argument `stop` given by `reps_before_termination`. Therefore, an additional "if stop brake" statement was added in this step.

- I'd like to highlight that the `AZPSimulatedAnnealing` and default `AZP` approaches were ok and were not generating unusual results as I was suspecting.

- It is possible that the performance will be reduced (only for `AZPBasicTabu` and `AZPReactiveTabu`) since now whenever `_make_move` is called, it checks for spatial contiguity of the regions.


### Final comment: 

After these fixes, I tried many scenarios and I didn't run into any weird solution. Therefore, I want to work with the Philosophy "Everyone is innocent until proven guilty". That is, I believe that max-p generates feasible solutions and it is innocent now unless someone raises an actual reproducible example with code with any of the issues that this PR attempts to solve. In this case, I'd be happy to help to try to solve it.

Best,
Renan